### PR TITLE
Changed ugettext_lazy to gettext_lazy

### DIFF
--- a/src/pretix_ldap/__init__.py
+++ b/src/pretix_ldap/__init__.py
@@ -1,5 +1,5 @@
 from .ldap_connector import LDAPAuthBackend  # noqa
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 
 try:
     from pretix.base.plugins import PluginConfig
@@ -12,9 +12,9 @@ class PluginApp(PluginConfig):
     verbose_name = "pretix LDAP"
 
     class PretixPluginMeta:
-        name = ugettext_lazy("pretix LDAP")
+        name = gettext_lazy("pretix LDAP")
         author = "sohalt"
-        description = ugettext_lazy("LDAP authentication backend for pretix")
+        description = gettext_lazy("LDAP authentication backend for pretix")
         visible = True
         version = "0.1.2"
         compatibility = "pretix>=4.7.0"

--- a/src/pretix_ldap/ldap_connector.py
+++ b/src/pretix_ldap/ldap_connector.py
@@ -4,7 +4,7 @@ import re
 import logging
 from django import forms
 from django.contrib import messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from pretix.settings import config
 from pretix.base.auth import BaseAuthBackend
 


### PR DESCRIPTION
This fixes pretix-ldap for new versions of pretix.

See https://stackoverflow.com/questions/70656495/importerror-cannot-import-name-ugettext-lazy/72863681#72863681