### PR TITLE
Authentik compatibility

### DIFF
--- a/pretix_ldap/ldap_connector.py
+++ b/pretix_ldap/ldap_connector.py
@@ -1,5 +1,6 @@
 from ldap3 import Server, Connection
 from ldap3.utils.conv import escape_filter_chars
+from ldap3.utils.config import set_config_parameter, get_config_parameter
 import re
 import logging
 from django import forms
@@ -15,6 +16,11 @@ logger = logging.getLogger(__name__)
 class LDAPAuthBackend(BaseAuthBackend):
     def __init__(self):
         try:
+            self.excluded_attributes = get_config_parameter("ATTRIBUTES_EXCLUDED_FROM_CHECK")
+            self.excluded_attributes.append("createTimestamp")
+            self.excluded_attributes.append("modifyTimestamp")
+            set_config_parameter("ATTRIBUTES_EXCLUDED_FROM_CHECK", self.excluded_attributes)
+
             self.config = config
             self.server = Server(self.config.get("ldap", "bind_url"))
             self.connection = Connection(


### PR DESCRIPTION
[Authentik](https://goauthentik.io/) can work as an LDAP Identity Provider, but it does not support the LDAP attributes createTimestamp and modifyTimestamp [source](https://docs.goauthentik.io/docs/add-secure-apps/providers/ldap/). By default, the ldap3 library expects these two attributes in the LDAP responses and throws an error when they are not present.

Because of that, pretix-ldap is currently not compatible with Authentik.

This pull request adds both attributes to the excluded parameters of ldap3. This should not be a problem, as pretix-ldap does not use these attributes at all.